### PR TITLE
fixed whois domain tld parse

### DIFF
--- a/index.js
+++ b/index.js
@@ -161,7 +161,8 @@ function requestWhois(domain, options) {
  * @param {String} domain
  */
 function getWhoisServer(domain) {
-    const tld = tldjs.getPublicSuffix(domain),
+    const tmp = domain.split('.'),
+          tld = tmp[tmp.length -1],
           cname = tld + '.whois-servers.net',
           messege = { not_found: 'Whois Server `NOT FOUND`' };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "domain-info",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "keywords": [
     "domain",
     "dns",


### PR DESCRIPTION
I can not see the whois on the domain , such as `co.uk`.
Can not split the domain in the correct format, it does not pass a value to the `whois-server.net`.
