### PR TITLE
Fixed dns type `ANY` with array error

### DIFF
--- a/index.js
+++ b/index.js
@@ -264,12 +264,11 @@ module.exports.groper = (domain, types, opts, cb) => {
     const domainName = encodePuny(domain);
     let type, resourceTypes, server, timeout;
 
-    if(typeof types === 'string' && types !== 'ANY') {
-        resourceTypes = [types];
-    } else if(Array.isArray(types) || types === 'ANY') {
-        resourceTypes = types;
-    } else {
-        resourceTypes = ['A'];
+    if(typeof types === 'string') { resourceTypes = [types]; }
+    if(Array.isArray(types)) { resourceTypes = types; }
+
+    if(resourceTypes.indexOf('ANY') >= 0) {
+        resourceTypes = 'ANY';
     }
 
     type = validateDnsType(resourceTypes);

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function requestDns(domain, type, option, timeout) {
     if(!type) type = 'A';
 
     let types = [],
-        server = { address: '8.8.8.8', port: 53, type: 'tcp' };
+        server = { address: '8.8.8.8', port: 53, type: 'udp' };
 
     if(typeof type === 'string') types.push(type);
     if(type.length) types = type;
@@ -55,14 +55,13 @@ function requestDns(domain, type, option, timeout) {
             let requestOption = {
                 question: dns.Question(question_opts),
                 server: objectAssign(server, option),
-                timeout: 1000,
+                timeout: 2000,
                 cache: false
             };
 
             if(timeout) requestOption.timeout = timeout;
 
             const request = dns.Request(requestOption);
-
             request.on('timeout', () => {
                 callback(new Error('DNS request timed out'), null);
             });
@@ -85,6 +84,7 @@ function requestDns(domain, type, option, timeout) {
 
                 Object.keys(results).map((value, index) => {
                     let key = types[index];
+
                     response[key] = results[value];
                 });
 

--- a/test/test.js
+++ b/test/test.js
@@ -58,7 +58,7 @@ test.cb('.groper() types has ANY returns all types', t => {
             port: 53,
             type: 'udp'
         },
-        types = ['A', 'NS', 'MX', 'ANY'],
+        types = ['ANY', 'NS', 'MX'],
         domain = 'example.com',
         timeout = 3000;
 
@@ -68,11 +68,18 @@ test.cb('.groper() types has ANY returns all types', t => {
     }
 
     const callback = (error, data) => {
-        keys = Object.keys(data);
-
-        ['A', 'AAAA', 'NS', 'CNAME', 'PTR', 'NAPTR', 'TXT', 'MX', 'SRV', 'SOA', 'TLSA'].foreach((val) => {
-            t.true(ketys.indexOf(val) !== -1);
-        });
+        t.true(!!data.A);
+        t.true(!!data.AAAA);
+        t.true(!!data.NS);
+        t.true(!!data.CNAME);
+        t.true(!!data.PTR);
+        t.true(!!data.NAPTR);
+        t.true(!!data.TXT);
+        t.true(!!data.MX);
+        t.true(!!data.SRV);
+        t.true(!!data.SOA);
+        t.true(!!data.TLSA);
+        t.end();
     }
 
     domainInfo.groper(domain, types, options, callback);

--- a/test/test.js
+++ b/test/test.js
@@ -52,6 +52,32 @@ test.cb('.groper() return domain resource record.', t => {
     domainInfo.groper(domain, types, options, callback);
 });
 
+test.cb('.groper() types has ANY returns all types', t => {
+    const server = {
+            address: '8.8.8.8',
+            port: 53,
+            type: 'udp'
+        },
+        types = ['A', 'NS', 'MX', 'ANY'],
+        domain = 'example.com',
+        timeout = 3000;
+
+    const options = {
+        server: server,
+        timeout: timeout
+    }
+
+    const callback = (error, data) => {
+        keys = Object.keys(data);
+
+        ['A', 'AAAA', 'NS', 'CNAME', 'PTR', 'NAPTR', 'TXT', 'MX', 'SRV', 'SOA', 'TLSA'].foreach((val) => {
+            t.true(ketys.indexOf(val) !== -1);
+        });
+    }
+
+    domainInfo.groper(domain, types, options, callback);
+});
+
 test('.groper() enable encode punycode domain', t => {
     const domain = '日本語.jp',
           type = 'A';


### PR DESCRIPTION
If using dns type `ANY` with array.

``` js
domainInfo.groper('github.com', ['ANY'])
```

it throw error below

```
Error: Valid No `DNS TYPE` exitst
    at Object.async.map.request.on.recordTypes.forEach.getWhoisDomain.then.module.exports.groper.promise.then.data.catch [as groper] (domain-info/index.js:278:15)
```

is fixed.

and default socket connection use `udp`
