### PR TITLE
Groper Example and fixed WhoIs lookups for large entities.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -55,15 +55,16 @@ Option is [node-dns](https://github.com/tjfontaine/node-dns#request) Request met
 
 ```js
 const domain = require('domain-info');
-domain.groper(
-    'example.com',
-    {
-        type: ['A', 'NS', 'MX'],
-        server: { address: '8.8.8.8', port: 53, type: 'udp' },
-        timeout: 1000
-    },
-    callback
-);
+
+// Build out your lookups and options
+var type = ['A', 'NS', 'MX']
+var options = {
+    server: { address: '8.8.8.8', port: 53, type: 'udp' },
+    timeout: 1000
+    }
+
+// Pass them into the groper method
+domain.groper('example.com', type, options, callback);
 ```
 
 ### reverse(ip_address, [callback])

--- a/index.js
+++ b/index.js
@@ -329,6 +329,31 @@ module.exports.whois = (domain, opts, cb) => {
     }
 }
 
+module.exports.exactWhois = (domain, opts, cb) => {
+    if (typeof domain !== 'string') {
+        throw new Error('Expected a `domain`');
+    }
+
+    if(typeof opts === 'function') cb = opts;
+
+    if(tldjs.tldExists(domain) === false) {
+        throw new Error('Invalid a `domain name`');
+    }
+    
+    // Pre-pending lookups with 'domain ' result in exact searches
+    // When this is not done your results will be for the domain you want and many spam domains as well
+    const encodedDomain = 'domain ' + encodePuny(domain),
+          promise = requestWhois(encodedDomain, opts);
+
+    if(cb && typeof cb === 'function') {
+        promise
+            .then(data => cb(null, data))
+            .catch(error => cb(error, null));
+    } else {
+        return promise;
+    }
+}
+
 module.exports.punycode = (domain_or_string) => {
     const type = domain_or_string.match(/^xn--/)? 'decode' : 'encode';
     if(type === 'decode') {


### PR DESCRIPTION
### Summary

The .groper example doesn't work as it lumps the types array and options in one, but the method takes them separate. Also would suggest adding a separate whois function for using for single domain lookups or fix the original .whois() method so that it prepends the search with 'domain ' in front of the searched domains if the whois server is 'whois.verisign-grs.com'

### Other Information

https://superuser.com/questions/37954/how-to-use-command-line-whois-for-spam-infected-domains-like-apple-com